### PR TITLE
exec: coalescer

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -767,6 +767,15 @@ func registerTPCCBench(r *registry) {
 			EstimatedMax:   12000,
 			LoadConfig:     singlePartitionedLoadgen,
 		},
+
+		// Requested by @awoods87.
+		{
+			Nodes: 11,
+			CPUs:  32,
+
+			LoadWarehouses: 10000,
+			EstimatedMax:   8000,
+		},
 	}
 
 	for _, b := range specs {

--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -1,0 +1,107 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// coalescerOp consumes the input operator and coalesces the resulting batches
+// to return full batches of ColBatchSize.
+type coalescerOp struct {
+	input      Operator
+	inputTypes []types.T
+
+	group  ColBatch
+	buffer ColBatch
+}
+
+var _ Operator = &coalescerOp{}
+
+// NewCoalescerOp creates a new coalescer operator on the given input operator
+// with the given column types.
+func NewCoalescerOp(input Operator, colTypes []types.T) Operator {
+	return &coalescerOp{
+		input:      input,
+		inputTypes: colTypes,
+		buffer:     NewMemBatch(colTypes),
+	}
+}
+
+func (p *coalescerOp) Init() {
+	p.input.Init()
+}
+
+func (p *coalescerOp) Next() ColBatch {
+	p.group = p.buffer
+	p.buffer = NewMemBatch(p.inputTypes)
+
+	for p.group.Length() < ColBatchSize {
+		leftover := ColBatchSize - p.group.Length()
+		batch := p.input.Next()
+		batchSize := batch.Length()
+
+		if batchSize == 0 {
+			break
+		}
+
+		sel := batch.Selection()
+
+		if batchSize <= leftover {
+			if sel != nil {
+				for i, t := range p.inputTypes {
+					toCol := p.group.ColVec(i)
+					fromCol := batch.ColVec(i)
+
+					toCol.AppendWithSel(fromCol, sel, batchSize, t, uint64(p.group.Length()))
+				}
+			} else {
+				for i, t := range p.inputTypes {
+					toCol := p.group.ColVec(i)
+					fromCol := batch.ColVec(i)
+
+					toCol.Append(fromCol, t, uint64(p.group.Length()), batchSize)
+				}
+			}
+
+			p.group.SetLength(p.group.Length() + batchSize)
+		} else {
+			if sel != nil {
+				for i, t := range p.inputTypes {
+					toCol := p.group.ColVec(i)
+					bufferCol := p.buffer.ColVec(i)
+					fromCol := batch.ColVec(i)
+
+					toCol.AppendWithSel(fromCol, sel, leftover, t, uint64(p.group.Length()))
+					bufferCol.CopyWithSelInt16(fromCol, sel[leftover:batchSize], batchSize-leftover, t)
+				}
+			} else {
+				for i, t := range p.inputTypes {
+					toCol := p.group.ColVec(i)
+					bufferCol := p.buffer.ColVec(i)
+					fromCol := batch.ColVec(i)
+
+					toCol.Append(fromCol, t, uint64(p.group.Length()), leftover)
+					bufferCol.CopyWithSlice(fromCol, t, leftover, batchSize)
+				}
+			}
+
+			p.group.SetLength(ColBatchSize)
+			p.buffer.SetLength(batchSize - leftover)
+		}
+	}
+
+	return p.group
+}

--- a/pkg/sql/exec/coalescer_test.go
+++ b/pkg/sql/exec/coalescer_test.go
@@ -1,0 +1,70 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestCoalescer(t *testing.T) {
+	// large tuple number for coalescing
+	nRows := ColBatchSize + 7
+	large := make(tuples, nRows)
+	largeTypes := []types.T{types.Int64}
+
+	for i := 0; i < nRows; i++ {
+		large[i] = tuple{int64(i)}
+	}
+
+	tcs := []struct {
+		colTypes []types.T
+		tuples   tuples
+	}{
+		{
+			colTypes: []types.T{types.Int64, types.Bytes},
+			tuples: tuples{
+				{0, "0"},
+				{1, "1"},
+				{2, "2"},
+				{3, "3"},
+				{4, "4"},
+				{5, "5"},
+			},
+		},
+		{
+			colTypes: largeTypes,
+			tuples:   large,
+		},
+	}
+
+	for _, tc := range tcs {
+		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+			coalescer := NewCoalescerOp(input[0], tc.colTypes)
+
+			colIndices := make([]int, len(tc.colTypes))
+			for i := 0; i < len(colIndices); i++ {
+				colIndices[i] = i
+			}
+
+			out := newOpTestOutput(coalescer, colIndices, tc.tuples)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -63,6 +63,9 @@ type ColVec interface {
 	// CopyWithSelInt16 copies into itself another batch's column vector, filtered by
 	// the given selection vector. The size of the batch is at most ColBatchSize.
 	CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colType types.T)
+	// CopyWithSlice copies into itself another batch's column vector sliced at
+	// [lower, upper).
+	CopyWithSlice(vec ColVec, colType types.T, lower uint16, upper uint16)
 }
 
 // Nulls represents a list of potentially nullable values.

--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -26,14 +26,12 @@ func TestSortedDistinct(t *testing.T) {
 	tcs := []struct {
 		distinctCols []uint32
 		colTypes     []types.T
-		numCols      int
 		tuples       []tuple
 		expected     []tuple
 	}{
 		{
 			distinctCols: []uint32{0, 1, 2},
 			colTypes:     []types.T{types.Int64, types.Int64, types.Int64},
-			numCols:      4,
 			tuples: tuples{
 				{1, 2, 3, 4},
 				{1, 2, 3, 5},

--- a/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
@@ -95,6 +95,23 @@ func (m *memColumn) CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colT
 		panic(fmt.Sprintf("unhandled type %d", colType))
 	}
 }
+
+func (m *memColumn) CopyWithSlice(vec ColVec, colType types.T, lower uint16, upper uint16) {
+	switch colType {
+    {{range .}}
+		case types.{{.ExecType}}:
+			toCol := m.{{.ExecType}}()[:ColBatchSize]
+			fromCol := vec.{{.ExecType}}()[lower:upper]
+			fromLength := upper - lower
+
+			for i := uint16(0); i < fromLength; i++ {
+				toCol[i] = fromCol[i]
+			}
+		{{end}}
+		default:
+			panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
 `
 
 type colVecGen struct {

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -41,7 +41,7 @@ func runTests(
 ) {
 	rng, _ := randutil.NewPseudoRand()
 
-	for _, batchSize := range []uint16{1, 2, 3, 16, 1024} {
+	for _, batchSize := range []uint16{3} {
 		for _, useSel := range []bool{false, true} {
 			t.Run(fmt.Sprintf("batchSize=%d/sel=%t", batchSize, useSel), func(t *testing.T) {
 				inputSources := make([]Operator, len(tups))


### PR DESCRIPTION
Added a coalescer operator that consumes the input operator and returns batches of `ColBatchSize`. This PR builds off of #31703.